### PR TITLE
fix infinite loop caused by duck-punching coffee-script more than once

### DIFF
--- a/src/coffee-react-script.coffee
+++ b/src/coffee-react-script.coffee
@@ -7,34 +7,38 @@ helpers = require './helpers'
 
 CoffeeScript = require 'coffee-script/lib/coffee-script/coffee-script'
 
-CoffeeScript.FILE_EXTENSIONS.push '.cjsx'
+unless CoffeeScript._cjsx
 
-CoffeeScript.register = -> require './register'
+  CoffeeScript._cjsx = yes
 
-# real coffeescript compile func, which we're wrapping
-CoffeeScript._csCompile = CoffeeScript.compile
+  CoffeeScript.FILE_EXTENSIONS.push '.cjsx'
 
-CoffeeScript.compile = (code, options) ->
-  input = transform(code)
+  CoffeeScript.register = -> require './register'
 
-  CoffeeScript._csCompile input, options
+  # real coffeescript compile func, which we're wrapping
+  CoffeeScript._csCompile = CoffeeScript.compile
 
-CoffeeScript._compileFile = (filename, sourceMap = no) ->
-  raw = fs.readFileSync filename, 'utf8'
-  stripped = if raw.charCodeAt(0) is 0xFEFF then raw.substring 1 else raw
-  
-  try
-    answer = CoffeeScript.compile(stripped, {filename, sourceMap, literate: helpers.isLiterate filename})
-  catch err
-    # As the filename and code of a dynamically loaded file will be different
-    # from the original file compiled with CoffeeScript.run, add that
-    # information to error so it can be pretty-printed later.
-    throw helpers.updateSyntaxError err, input, filename
+  CoffeeScript.compile = (code, options) ->
+    input = transform(code)
 
-  answer
+    CoffeeScript._csCompile input, options
 
-CoffeeScript.hasCJSXPragma = helpers.hasCJSXPragma
-CoffeeScript.hasCJSXExtension = helpers.hasCJSXExtension
-CoffeeScript.transform = transform
+  CoffeeScript._compileFile = (filename, sourceMap = no) ->
+    raw = fs.readFileSync filename, 'utf8'
+    stripped = if raw.charCodeAt(0) is 0xFEFF then raw.substring 1 else raw
+
+    try
+      answer = CoffeeScript.compile(stripped, {filename, sourceMap, literate: helpers.isLiterate filename})
+    catch err
+      # As the filename and code of a dynamically loaded file will be different
+      # from the original file compiled with CoffeeScript.run, add that
+      # information to error so it can be pretty-printed later.
+      throw helpers.updateSyntaxError err, input, filename
+
+    answer
+
+  CoffeeScript.hasCJSXPragma = helpers.hasCJSXPragma
+  CoffeeScript.hasCJSXExtension = helpers.hasCJSXExtension
+  CoffeeScript.transform = transform
 
 module.exports = CoffeeScript


### PR DESCRIPTION
Because of the way that `coffee-react` is duck-punching / monkey-patching the `coffee-script` module, it causes an infinite loop if two distinct of `coffee-react` modules are `require()`'d and then you attempt to parse compile `.cjsx` files into JavaScript.

This took a long time to debug but the fix was pretty simple. All I did was add a `_cjsx` property to the `CoffeeScript` object. If it already exists, it won't try to modify it a second time. I would be very happy if this could get merged in, and `coffee-reactify` could be updated to use the new version.
