### PR TITLE
Update Coffeescript to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "coffee-react-transform": "^2.4.1",
-    "coffee-script": "1.8.0",
+    "coffee-script": "^1.9.1",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "coffee-react"
   ],
   "author": "James Friend",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
At the moment `coffee-react` overrides Coffeescript to 1.8.0 when required, breaking my serverside `.coffee` 1.9.1 code.