### PR TITLE
Don't mutate original CS module

### DIFF
--- a/src/coffee-react-script.coffee
+++ b/src/coffee-react-script.coffee
@@ -5,7 +5,8 @@ transform = require 'coffee-react-transform'
 
 helpers = require './helpers'
 
-CoffeeScript = require 'coffee-script/lib/coffee-script/coffee-script'
+CoffeeScript = Object.assign {},
+  require 'coffee-script/lib/coffee-script/coffee-script'
 
 jsSyntaxTransform = require 'coffee-react-jstransform'
 
@@ -13,7 +14,7 @@ unless CoffeeScript._cjsx
 
   CoffeeScript._cjsx = yes
 
-  CoffeeScript.FILE_EXTENSIONS.push '.cjsx'
+  CoffeeScript.FILE_EXTENSIONS = [CoffeeScript.FILE_EXTENSIONS..., '.cjsx']
 
   CoffeeScript.register = -> require './register'
 


### PR DESCRIPTION
Hello.
I know that the package is deprecated, but our production code depends on it.
So, the thing is that your code mutates the original coffee-script module and this affects the other code that depends on the original module (`coffee-loader` for webpack gets broken in my case).
This PR fixes the issue by making `coffee-react` clone the CS module and then mutating it to keep the original untouched.
Could you please merge this in and publish a fixed version to the npm?